### PR TITLE
[24.03.21] 로그인페이지, 공통Input, pagiantion 생성 및 레이아웃 조정

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@lucasmogari/react-pagination": "^1.2.0",
     "@types/lodash": "^4.17.0",
     "@types/react-table": "^7.7.20",
     "autoprefixer": "^10.4.18",
@@ -17,6 +18,7 @@
     "clsx": "^2.1.0",
     "lodash": "^4.17.21",
     "postcss": "^8.4.36",
+    "query-string": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.0",

--- a/src/components/@common/Input.tsx
+++ b/src/components/@common/Input.tsx
@@ -1,0 +1,52 @@
+import { FieldErrors,UseFormRegister } from 'react-hook-form'
+import cn from '../../lib/tailwindUtil'
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement>{
+  id: string
+  type: string
+  label: string
+  disabled?: boolean
+  required?: boolean
+  formatprice?: boolean
+  register: UseFormRegister<any>
+  errors: FieldErrors
+}
+
+const Input = ({
+  id,
+  type,
+  label,
+  disabled,
+  required,
+  register,
+  errors,
+  formatprice,
+  ...props
+}:InputProps) => {
+  return (
+    <div className="relative w-full">
+      {
+        formatprice && (
+          <span className="absolute top-[18px] left-3">￦</span>
+        )
+      }
+      <input
+        id={id}
+        type={type}
+        disabled={disabled}
+        {...register(id, {required:required})}
+        placeholder=''
+        {...props}
+        className={cn("w-full outline-none rounded-md p-4 peer disabled:opacity-70 disabled:cursor-not-allowed",formatprice ? "pl-9" : "pl-4", errors![id] && "border-red-500", errors![id] ?"focus:border-rose-500" :"focus:border-[#000fff]" )}
+      />
+      <label
+        htmlFor={id}
+        className={cn("absolute text-sm rounded-md text-gray-500 dark:text-gray-400 duration-300 transform -translate-y-4 scale-75 top-2 z-10 origin-[0] bg-white dark:bg-gray-900 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4  rtl:peer-focus:translate-x-1/4 rtl:peer-focus:left-auto start-3")}
+      >
+        {label}
+      </label>
+    </div>
+  )
+}
+
+export default Input

--- a/src/components/@common/Layout.tsx
+++ b/src/components/@common/Layout.tsx
@@ -8,8 +8,8 @@ export interface LayoutProps {
 const Layout = (props: LayoutProps) => {
   const { children } = props
   return (
-    <div className="flex justify-center w-full h-screen">
-      <div className="relative flex w-[1300px] h-screen">
+    <div className="flex justify-center w-full h-screen max-w-[2520px]">
+      <div className="relative flex w-full h-screen">
         <Sidebar />
         <div className="w-full h-full bg-[#fafafa]">{children}</div>
       </div>

--- a/src/components/@common/Pagination.tsx
+++ b/src/components/@common/Pagination.tsx
@@ -1,0 +1,46 @@
+import usePagination from '@lucasmogari/react-pagination'
+import PaginationLink from './PaginationLink'
+interface PaginationProps{
+  totalItems:number
+  page?:number
+}
+const Pagination = ({
+  totalItems,
+  page=1,
+}:PaginationProps) => {
+
+  const { getPageItem, totalPages} = usePagination({
+    totalItems,
+    page,
+    itemsPerPage:10,
+    maxPageItems:5,
+  })
+
+  const firstPage = 1
+  const nextPage = Math.min(page + 1, totalPages)
+  const previousPage = Math.max(page - 1, firstPage)
+
+  const arr = new Array(totalPages + 2)
+  return (
+    <div>
+      {
+        [...arr].map((_,index)=>{
+          const {page,disabled,current} = getPageItem(index)
+          if(page === 'previous') {
+            return (<PaginationLink page={previousPage} disabled={disabled} active={current} key={index}>{"<"}</PaginationLink>)
+          }
+
+          if(page === 'next') {
+            return <PaginationLink page={nextPage} disabled={disabled} active={current} key={index}>{">"}</PaginationLink>;
+          }
+          if(page === 'gap') {
+            return <PaginationLink key={index}>{"..."}</PaginationLink>;            
+          }
+          return (<PaginationLink page={page} active={current} key={index}>{page}</PaginationLink>)
+        })
+      }
+    </div>
+  )
+}
+
+export default Pagination

--- a/src/components/@common/PaginationLink.tsx
+++ b/src/components/@common/PaginationLink.tsx
@@ -1,0 +1,40 @@
+import { PropsWithChildren } from 'react';
+import queryString from 'query-string';
+import { Link, useLocation } from 'react-router-dom';
+
+
+type PaginationLinkProps = {
+    page?: number;
+    disabled?: boolean;
+    active?: boolean;
+} & PropsWithChildren
+
+const PaginationLink = ({ page, disabled, active, children }: PaginationLinkProps) => {
+    const location = useLocation();
+    const params = location.search;
+    const path = location.pathname;
+    const limit = 10;
+    const skip = page ? (Number(page) - 1) * limit : 0; 
+
+    let currentQuery = {};
+    if(params) {
+        currentQuery = queryString.parse(params?.toString())
+    }
+    const updatedQuery = {
+        ...currentQuery, 
+        page,
+        skip
+    }
+
+  return (
+    <Link
+      to={`${path}?${queryString.stringify(updatedQuery)}`} 
+      className={`p-2 text-xl 
+      ${active ? "font-bold text-black" :""}
+      ${disabled ? "pointer-events-none text-gray-200" : ""}
+      `}
+    >{children}</Link>
+  )
+}
+
+export default PaginationLink

--- a/src/pages/Author.tsx
+++ b/src/pages/Author.tsx
@@ -4,6 +4,7 @@ import Wrapper from '../components/@common/Wrapper'
 import Button, { type } from '../components/@common/Button'
 import TInteraction from '../components/@common/table/TInteraction'
 import Table from '../components/@common/table/Table'
+import Pagination from '../components/@common/Pagination'
 
 const AuthorPage = () => {
   const [startDate, setStartDate] = useState<string>()
@@ -79,7 +80,7 @@ const AuthorPage = () => {
                 />
               </div>
             </div>
-            <div className="flex items-center justify-center h-14">12345</div>
+            <Pagination totalItems={10} page={2} />
           </section>
         </div>
       </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,46 @@
+import { FieldValues, SubmitHandler, useForm } from 'react-hook-form'
+import logo from '../assets/logo.webp'
+import Input from '../components/@common/Input'
+import Button, { type } from '../components/@common/Button'
+import { useNavigate } from 'react-router-dom'
+
+const LoginPage = () => {
+  const router = useNavigate()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FieldValues>({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  })
+
+  const onSubmit: SubmitHandler<FieldValues> = async (body) => {
+    router('/main')
+  }
+
+  return (
+    <section className="h-[calc(100vh_-_56px)] flex flex-col justify-center items-center">
+      <div className='max-w-screen-md flex flex-col min-h-[640px] justify-center items-center gap-12 bg-main-medium rounded-lg'>
+        <div className="flex justify-center items-center">
+          <img className="w-[57%]" src={logo} />
+        </div>
+        <form className="flex flex-col justify-center gap-4 min-w-[350px]">
+          <h1 className="text-2xl text-white">시작하기</h1>
+          <Input type="text" label="Email" id="email" required={true} errors={errors} register={register} />
+          <Input type="password" label="Password" id="password" required={true} errors={errors} register={register} />
+          <Button onClick={handleSubmit(onSubmit)} className='bg-white px-6 py-3 text-lg rounded-md mb-10'>
+            로그인
+          </Button>
+          <div className="flex w-full justify-center">
+            <p className="text-white opacity-90">관리자 전용 페이지 입니다.</p>
+          </div>
+        </form>
+      </div>
+    </section>
+  )
+}
+
+export default LoginPage

--- a/src/pages/Login/page.tsx
+++ b/src/pages/Login/page.tsx
@@ -1,5 +1,0 @@
-const LoginPage = () => {
-  return <div>LoginPage</div>
-}
-
-export default LoginPage

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route } from 'react-router-dom'
-import LoginPage from '../pages/Login/page'
+import LoginPage from '../pages/Login'
 import MainPage from '../pages/Main'
 import UserPage from '../pages/User'
 import AuthorPage from '../pages/Author'

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,6 +456,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@lucasmogari/react-pagination@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@lucasmogari/react-pagination/-/react-pagination-1.2.0.tgz#9dd1fceb6152597f983e90725f18f65a087549c6"
+  integrity sha512-B+67nVJhzk8ACn81ISjha8+B58dfOdFLYjEYtmVWLuEaWYbD0ogyPttbG2VwlGFFDU23Rjc3fDlT4QY+g6sNYA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1309,6 +1314,11 @@ debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+decode-uri-component@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz#2ac4859663c704be22bf7db760a1494a49ab2cc5"
+  integrity sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -1748,6 +1758,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-5.1.0.tgz#5bd89676000a713d7db2e197f660274428e524ed"
+  integrity sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==
 
 finalhandler@1.1.1:
   version "1.1.1"
@@ -2953,6 +2968,15 @@ qs@6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-9.0.0.tgz#1fe177cd95545600f0deab93f5fb02fd4e3e7273"
+  integrity sha512-4EWwcRGsO2H+yzq6ddHcVqkCQ2EFUSfDMEjF8ryp8ReymyZhIuaFRGLomeOQLkrzacMHoyky2HW0Qe30UbzkKw==
+  dependencies:
+    decode-uri-component "^0.4.1"
+    filter-obj "^5.1.0"
+    split-on-first "^3.0.0"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -3323,6 +3347,11 @@ source-map-js@^1.1.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.1.0.tgz#9e7d5cb46f0689fb6691b30f226937558d0fa94b"
   integrity sha512-9vC2SfsJzlej6MAaMPLu8HiBSHGdRAJ9hVFYN1ibZoNkeanmDmLUcIrj6G9DGL7XMJ54AKg/G75akXl1/izTOw==
 
+split-on-first@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-3.0.0.tgz#f04959c9ea8101b9b0bbf35a61b9ebea784a23e7"
+  integrity sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==
+
 split2@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.0.0.tgz#55057cd560687a7ef6464471597404577ff1735d"
@@ -3352,16 +3381,8 @@ stethoskop@1.0.0:
   dependencies:
     node-statsd "0.1.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3427,14 +3448,8 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
## paginaiton 사용법
- tatalItems : 아이템의 전체 갯수
- page : 현재 페이지 번호

URL에 Query String으로 페이지 이동
1이라면 1페이지
3이라면 3페이지의 아이템을 보여줌.

## 레이아웃 구조 변경
- 레이아웃의 너비를 화면에 꽉 채우도록 변경
